### PR TITLE
Support BINDIR in make invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PREFIX?=/usr
+BINDIR=${PREFIX}/games
 DATADIR=${PREFIX}/share/wordwarvi
 MANDIR?=${PREFIX}/share/man
 MANPAGEDIR=${MANDIR}/man6
@@ -116,15 +117,15 @@ wordwarvi.6.gz:	wordwarvi.6
 	gzip -c wordwarvi.6 > wordwarvi.6.gz
 
 install: wordwarvi wordwarvi.6.gz
-	mkdir -p $(DESTDIR)$(PREFIX)/games
+	mkdir -p $(DESTDIR)$(BINDIR)
 	mkdir -p $(DESTDIR)$(DATADIR)/sounds
 	mkdir -p $(DESTDIR)$(MANPAGEDIR)
-	install -p -m 755 wordwarvi $(DESTDIR)$(PREFIX)/games
+	install -p -m 755 wordwarvi $(DESTDIR)$(BINDIR)
 	install -p -m 644 sounds/*.ogg $(DESTDIR)$(DATADIR)/sounds
 	install -p -m 644 wordwarvi.6.gz $(DESTDIR)$(MANPAGEDIR)
 
 uninstall:
-	/bin/rm -f $(DESTDIR)${PREFIX}/games/wordwarvi
+	/bin/rm -f $(DESTDIR)$(BINDIR)/wordwarvi
 	/bin/rm -fr $(DESTDIR)${DATADIR}
 	/bin/rm -f $(DESTDIR)${MANPAGEDIR}/wordwarvi.6.gz
 


### PR DESCRIPTION
This is useful for package creators to be able to run `make install`
without having to move files around afterwards.