### PR TITLE
Default BUILD_CC to CC to simplify native build setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ OPENLASELIBDIR=
 endif
 
 CC ?= gcc
-BUILD_CC ?= gcc
+BUILD_CC ?= ${CC}
 
 # DEBUG=-g
 # DEBUG=


### PR DESCRIPTION
Make it so it's enough to just set CC to use correct compiler for a native build